### PR TITLE
chore: bump maximum Dart SDK

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 3.0.3
 homepage: https://github.com/alexei-sintotski/pubspec_lock
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: ">=2.12.0 <4.0.0"
 
 dependencies:
   functional_data: ^1.0.0


### PR DESCRIPTION
Current maximum Dart SDK doesn't support Dart 3 versions.